### PR TITLE
Clear out TAR + fakeroot dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,6 @@ ifneq "$(DRYRUN)" ""
 ROPTS += --dry-run
 endif
 
-FAKEROOT:= $(shell which fakeroot >/dev/null && echo fakeroot || true)
-TAR	= $(FAKEROOT) tar
 RSYNC	= rsync -crlptvHxP --inplace --exclude old $(ROPTS)
 
 ################################


### PR DESCRIPTION
TAR isn't used, and thus fakeroot is a suprious lookup + error
since it's not really needed to actually build any of this.
Removing those two extraneous lines to clean up the build.